### PR TITLE
make the "services" collection visible to jekyll

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,9 @@ collections:
   activities:
     output: true
     permalink: /:path/
+  services:
+    output: true
+    permalink: /:path/
   people:
     output: true
     permalink: /:collection/:path/


### PR DESCRIPTION
This was missing to make the collection visible.

Please note that you can also write HTML directly if this is more convenient than separating data and form using variables.